### PR TITLE
port forward to rds

### DIFF
--- a/sssh
+++ b/sssh
@@ -96,7 +96,7 @@ Supported input parameters:
  -r | --region      : AWS Region to fetch the cluster, service, task
  -p | --profile     : AWS Profile for credentials and region.
  -c | --command     : Command to execute, defaults to '/bin/sh'/
-      --port        : Port number for port forward.
+      --remote-port : Remote port number for port forward.
       --local-port  : Local port number for port forward.
       --remote-host : Remote host name for port forward.
 
@@ -136,9 +136,9 @@ main(){
         command="${1:?Command must be specified in --command}"
         shift
         ;;
-      --port)
+      --remote-port)
         shift
-        port="${1:?port must be specified in --port}"
+        remotePort="${1:?remote-port must be specified in --remote-port}"
         shift
         ;;
       --local-port)
@@ -193,13 +193,13 @@ main(){
   colorEcho Container: $container
   echo_stderr
 
-  # Both port and localPort parameters are not supplied.
-  if [ -z ${port+x} ] && [ -z ${localPort+x} ] && [ -z ${remoteHost+x} ]; then
+  # None of the remotePort, localPort, remoteHost parameters are supplied.
+  if [ -z ${remotePort+x} ] && [ -z ${localPort+x} ] && [ -z ${remoteHost+x} ]; then
     cmd="aws ecs execute-command $(params) --cluster $cluster --container $container --task $task --interactive --command '$command'"
   else
     taskId=$(echo $task | awk -F '/' '{print $3}')
     containerId=$(aws ecs describe-tasks $(params) --cluster $cluster --task $task | jq -r --arg container $container '.tasks[0].containers[] | select(.name == $container).runtimeId')
-    cmd="aws ssm start-session $(params) --target ecs:${cluster}_${taskId}_${containerId} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters {\"host\":[\"${remoteHost:-"127.0.0.1"}\"],\"portNumber\":[\"${port-"3306"}\"],\"localPortNumber\":[\"$localPort\"]}"
+    cmd="aws ssm start-session $(params) --target ecs:${cluster}_${taskId}_${containerId} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters {\"host\":[\"${remoteHost:-"127.0.0.1"}\"],\"portNumber\":[\"${remotePort-"3306"}\"],\"localPortNumber\":[\"$localPort\"]}"
   fi
 
   colorEcho $cmd


### PR DESCRIPTION
# 概要
- 接続したコンテナからアクセス可能なホストへのポートフォワードを可能にする。

# 動作確認
```
# ssshを remote-host, port, local-port を指定して実行する
# stg-appなどのrdsに接続可能なコンテナに接続して、リモートホストへのポートフォワードを開始する
./sssh --remote-host stg.example.com --port 3306 --local-port 13306

# 別の端末でローカルに接続するとrdsなどのリモートホストへポートフォワードされる
mysql -h127.0.0.1 -P13306 -uDBUSER -pDBPASS DBNAME
```

# 参考
- [AWS System Managerセッションマネージャーがリモートホストのポートフォワードに対応しました](https://dev.classmethod.jp/articles/aws-ssm-support-remote-host-port-forward/#:~:text=localhost%20%2DP%203306-,%5BNEW%5DSSM%E3%81%A7%E3%83%AA%E3%83%A2%E3%83%BC%E3%83%88%E3%83%9B%E3%82%B9%E3%83%88%E3%81%AE%E3%83%9D%E3%83%BC%E3%83%88%E3%82%92%E8%BB%A2%E9%80%81,-%E4%BB%8A%E5%9B%9E%E7%99%BA%E8%A1%A8%E3%81%AB)