### PR TITLE
スペースを含む --command を実行できるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd sssh
 # Help
 ./sssh --help
 ```
-**Note**: Before running the script, ensure that your AWS CLI session profile is configured to output in JSON format. Otherwise, the script will crash. You can set the output format as JSON when you run `aws configure`.
+**Note**: Before running the script, ensure that the AWS CLI profile you use is configured to output in JSON format. Otherwise, the script will crash. Running `aws configure` only sets the `default` profile, so configure the profile you pass to `--profile` explicitly: `aws configure set output json --profile foo-profile`.
 
 **Note**: The exit code of the remote command is NOT reflected in the exit code of this script (an ECS Exec limitation), so it is not suitable for CI pipelines.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ cd sssh
 # Select profile, cluster, service, container, and task, and run sh
 ./sssh
 
+# Run a one-off command on the container ("--opt value" and "--opt=value" both work)
+./sssh --command "php -v"
+./sssh --command="php -v"
+
+# Pipes, redirects, and variable expansion require an explicit shell
+./sssh --command 'sh -c "php -v | head -n 1"'
+
 # Run port forwarding
 ./sssh --remote-host rds.example.com --remote-port 3306 --local-port 13306
 
@@ -33,7 +40,11 @@ cd sssh
 # Help
 ./sssh --help
 ```
-**Note**: Before running the script, ensure that your AWS CLI session profile is configured to output in JSON format. Otherwise, the script will crash. You can set the output format as JSON when you run `aws configure sso`.
+**Note**: Before running the script, ensure that your AWS CLI session profile is configured to output in JSON format. Otherwise, the script will crash. You can set the output format as JSON when you run `aws configure`.
+
+**Note**: The exit code of the remote command is NOT reflected in the exit code of this script (an ECS Exec limitation), so it is not suitable for CI pipelines.
+
+**Note**: Do not embed passwords or tokens in `--command`. The command line is shown on screen, kept in your local shell history, and recorded in CloudTrail; with ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.
 
 ## Special thanks to contributor
 - [leewc](https://github.com/leewc)

--- a/sssh
+++ b/sssh
@@ -40,6 +40,13 @@ die() {
   exit 1
 }
 
+# Extract the value from an "--opt=value" style argument.
+optValue() {
+  local val="${1#*=}"
+  [[ -n "$val" ]] || die "Value must be specified in ${1%%=*}"
+  echo "$val"
+}
+
 function print_help() {
   cat >&2 <<-END
 This script simplifies the process of getting the required information to drop into an
@@ -47,10 +54,10 @@ interactive shell script on your container hosted on Fargate/ECS.
 Example:
 ./sssh --region us-west-2
 ./sssh --profile default
-Supported input parameters:
+Supported input parameters (both "--opt value" and "--opt=value" forms work):
  -r | --region      : AWS Region to fetch the cluster, service, task
  -p | --profile     : AWS Profile for credentials and region.
- -c | --command     : Command to execute, defaults to '/bin/sh'/
+ -c | --command     : Command to execute, defaults to '/bin/sh'.
       --cluster     : Cluster name.
       --service     : Service name.
       --task        : Task name.
@@ -62,6 +69,14 @@ The default command executed on the selected container is '/bin/sh'.
 If a region is not provided, the script will attempt to use your region set in the profile.
 If you want to execute a different command or shell, you can pass it in like so:
 ./sssh --command '/bin/bash'
+./sssh --command 'php -v'
+Pipes, redirects, and variable expansion require an explicit shell:
+./sssh --command 'sh -c "php -v | head -n 1"'
+Note: the exit code of the remote command is NOT reflected in the exit code of
+this script (an ECS Exec limitation).
+Note: do not embed passwords or tokens in --command. The command line is shown
+on screen, kept in your local shell history, and recorded in CloudTrail; with
+ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.
 You need active (unexpired) AWS credentials, otherwise, the script will crash.
 END
 }
@@ -75,7 +90,7 @@ main(){
         exit
         ;;
       -v|--version)
-        echo "sssh version v4.1.1"
+        echo "sssh version v4.2.0"
         exit
         ;;
       -r|--region)
@@ -83,56 +98,67 @@ main(){
         region="${1:?Region must be specified in --region}"
         shift
         ;;
+      --region=*) region=$(optValue "$1"); shift ;;
       -p|--profile)
         shift
         profile="${1:?Profile must be specified in --profile}"
         shift
         ;;
+      --profile=*) profile=$(optValue "$1"); shift ;;
       -o|--otp)
         shift
         otp="${1:?OTP must be specified in --otp}"
         shift
         ;;
+      --otp=*) otp=$(optValue "$1"); shift ;;
       -c|--command)
         shift
         command="${1:?Command must be specified in --command}"
         shift
         ;;
+      --command=*) command=$(optValue "$1"); shift ;;
       --cluster)
         shift
         cluster="${1:?Cluster must be specified in --cluster}"
         shift
         ;;
+      --cluster=*) cluster=$(optValue "$1"); shift ;;
       --service)
         shift
         service="${1:?Service must be specified in --service}"
         shift
         ;;
+      --service=*) service=$(optValue "$1"); shift ;;
       --task)
         shift
         task="${1:?Task must be specified in --task}"
         shift
         ;;
+      --task=*) task=$(optValue "$1"); shift ;;
       --container)
         shift
         container="${1:?Container must be specified in --container}"
         shift
         ;;
+      --container=*) container=$(optValue "$1"); shift ;;
       --remote-host)
         shift
         remoteHost="${1:?remote-host must be specified in --remote-host}"
         shift
         ;;
+      --remote-host=*) remoteHost=$(optValue "$1"); shift ;;
       --remote-port)
         shift
         remotePort="${1:?remote-port must be specified in --remote-port}"
         shift
         ;;
+      --remote-port=*) remotePort=$(optValue "$1"); shift ;;
       --local-port)
         shift
         localPort="${1:?local-port must be specified in --local-port}"
         shift
         ;;
+      --local-port=*) localPort=$(optValue "$1"); shift ;;
       *)
         die "Unknown param $1"
         ;;
@@ -187,18 +213,25 @@ main(){
   colorEcho Container: $container
   echo_stderr
 
+  # Build the final command as a bash array so that arguments containing
+  # spaces (e.g. --command 'php -v') keep their word boundaries.
+  # ${awsParams[@]+...} guards the empty-array case under set -u on bash 3.2.
+  awsParams=()
+  [[ -n "${profile:-}" ]] && awsParams+=(--profile "$profile")
+  [[ -n "${region:-}" ]] && awsParams+=(--region "$region")
+
   # None of the remotePort, localPort, remoteHost parameters are supplied.
   if [ -z ${remotePort+x} ] && [ -z ${localPort+x} ] && [ -z ${remoteHost+x} ]; then
-    cmd="aws ecs execute-command $(params) --cluster $cluster --container $container --task $task --interactive --command '$command'"
+    cmd=(aws ecs execute-command ${awsParams[@]+"${awsParams[@]}"} --cluster "$cluster" --container "$container" --task "$task" --interactive --command "$command")
   else
     taskId=$(echo $task | awk -F '/' '{print $3}')
     containerId=$(aws ecs describe-tasks $(params) --cluster $cluster --task $task | jq -r --arg container $container '.tasks[0].containers[] | select(.name == $container).runtimeId')
-    cmd="aws ssm start-session $(params) --target ecs:${cluster}_${taskId}_${containerId} --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters {\"host\":[\"${remoteHost:-"127.0.0.1"}\"],\"portNumber\":[\"${remotePort:-"3306"}\"],\"localPortNumber\":[\"$localPort\"]}"
+    cmd=(aws ssm start-session ${awsParams[@]+"${awsParams[@]}"} --target "ecs:${cluster}_${taskId}_${containerId}" --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters "{\"host\":[\"${remoteHost:-127.0.0.1}\"],\"portNumber\":[\"${remotePort:-3306}\"],\"localPortNumber\":[\"$localPort\"]}")
   fi
 
-  colorEcho $cmd
-  $cmd
+  colorEcho "${cmd[@]}"
+  "${cmd[@]}"
 }
 
 # Execute main function and pass all params over
-main $@
+main "$@"

--- a/sssh
+++ b/sssh
@@ -44,7 +44,7 @@ die() {
 optValue() {
   local val="${1#*=}"
   [[ -n "$val" ]] || die "Value must be specified in ${1%%=*}"
-  echo "$val"
+  printf '%s\n' "$val"
 }
 
 function print_help() {
@@ -215,7 +215,8 @@ main(){
 
   # Build the final command as a bash array so that arguments containing
   # spaces (e.g. --command 'php -v') keep their word boundaries.
-  # ${awsParams[@]+...} guards the empty-array case under set -u on bash 3.2.
+  # ${awsParams[@]+...} guards against "unbound variable" under set -u on
+  # bash 3.2, which treats an empty array as unset.
   awsParams=()
   [[ -n "${profile:-}" ]] && awsParams+=(--profile "$profile")
   [[ -n "${region:-}" ]] && awsParams+=(--region "$region")


### PR DESCRIPTION
Closes #13

詳細設計: https://github.com/shueisha-arts-and-digital/sssh/issues/13#issuecomment-5422811013

## 何が課題か

`--command` にスペースを含むコマンド（例: `php -v`）を渡すと `Unknown param` で失敗するか、AWS CLI に壊れた引数が渡っていました。ヘルプに記載済みの公開インターフェースが記載どおり動かない状態でした。

## なぜ変更が必要か

対話シェルを開かずにワンショットでコマンドを実行したいケース（バージョン確認、単発のデバッグコマンドなど）で、現状はコンテナに入ってから手で打つしかないためです。

## 実装方針（なぜこの方法を選んだか）

根本原因は、引数が渡る経路の3箇所すべてでスペース入り文字列が壊れることでした。3箇所すべてを修正しています。

1. **`main $@` → `main "$@"`**
   クォートがないため bash が引数を再分割し、`--command "php -v"` が `--command` `php` `-v` の3つに割れていました。
2. **全オプションで `--opt=value` 形式に対応**
   case 文は「`--opt` の後に別引数で値」の形式のみ対応で、`--command="php -v"`（`=` 区切り）は `Unknown param` になっていました。`--command` だけ対応すると書式が混在して混乱するため、全11オプションで統一しています。空値（`--command=`）はエラーにします。
3. **最終コマンドを文字列ではなく bash 配列で組み立てて実行**
   `cmd="... --command '$command'"` の文字列内シングルクォートはシェルのクォートとして機能せず、`$cmd` 展開時の単語分割で AWS CLI に `'php` `-v'` と壊れた形で渡っていました。`cmd=(aws ecs execute-command ...)` + `"${cmd[@]}"` に変更し、引数境界を保持します。ポートフォワード分岐（`ssm start-session`）も同じ経路のため合わせて配列化しています。

### 他の選択肢と不採用理由

- **`eval "$cmd"`（差分1行）**: `--command` の文字列がローカルシェルで再解釈され、`$` やバッククォート、`;` が意図せず展開・実行されるリスクがあるため不採用。
- **`--command` のみ `=` 形式対応**: オプションごとに書式が異なると混乱するため不採用。

## 影響範囲・後方互換性

- 変更ファイルは `sssh` と `README.md` のみ。中間の `aws ecs list-*` / `describe-tasks` 呼び出しは変更していません。
- 破壊的変更はありません。対話モード・単一語の `--command`・ポートフォワードはすべて従来どおり動作します。
- macOS 標準の bash 3.2 で動作する構文のみ使用しています（`set -u` 下の空配列展開は `${awsParams[@]+...}` でガード）。
- バージョンを v4.1.1 → v4.2.0 に更新しました（機能追加のためマイナーバージョンアップ）。

## リスク・制約・未解決事項

- **秘密情報の露出**: `--command` の内容はローカルのシェル履歴・画面表示に平文で残り、ExecuteCommand の呼び出しは CloudTrail に記録されます。ECS Exec のロギング設定次第ではコマンドと出力が CloudWatch Logs / S3 にも保存されます。パスワードやトークンを直接埋め込まない旨を README と `--help` に明記しました。
- パイプ・リダイレクトは ECS Exec 側の制約でそのままでは効きません（`sh -c "..."` 経由が必要）。README に使用例を追記しました。
- リモートコマンドの終了コードは AWS CLI の終了コードに反映されません（ECS Exec の既知の制約）。CI 用途には不向きである旨を README に明記しました。

## 人間に確認・判断してほしい点

- `=` 形式を全オプションに広げる方針でよいか。
- v4.2.0 へのバージョンアップでよいか。
- 実環境の ECS Fargate コンテナに対する疎通確認は未実施です。マージ前にどなたか 1 回実行して確認をお願いします（下記の確認 1〜3 相当）。

## 動作確認方法と確認結果

AWS CLI をスタブ（渡された引数を1つずつ出力するだけのスクリプト）に差し替え、macOS 標準 bash 3.2.57 で最終的に AWS CLI へ渡る引数の境界を検証しました。

| ケース | 結果 |
|---|---|
| `--command "php -v"` | ✅ 値が `php -v` の1引数として渡る |
| `--command="php -v"` | ✅ 同上 |
| `--command` 省略 | ✅ 従来どおり `/bin/sh` |
| `--command 'sh -c "php -v \| head -n 1"'` | ✅ 全体が1引数として渡る |
| ポートフォワード | ✅ 従来どおりの `ssm start-session` 引数（`--parameters` の JSON が正しく1引数になる） |
| `--command=`（空値） | ✅ exit 1 で `Value must be specified in --command` |
| `--region=us-west-2` 併用 | ✅ `--region us-west-2` が正しく挿入される |
| `--help` / `--version` / 不明オプション | ✅ 正常動作 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * コマンドラインオプションの値をより安全かつ正確に扱えるようになりました。
  * AWSパラメータの処理を改善し、環境による不具合を防ぎやすくしました。

* **ドキュメント**
  * ECSコンテナ上で単発コマンドを実行する例を追加しました。
  * パイプ、リダイレクト、変数展開には明示的なシェルが必要であることを明記しました。
  * AWS CLIプロファイルのJSON出力設定と`--profile`の指定方法を更新しました。
  * リモートコマンドの終了コード制限と、機密情報の取り扱いに関する注意事項を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->