### PR TITLE
情報メッセージをstderrに統一し、リモートコマンドの終了コードをデフォルトで伝搬

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Session Manager plugin for the AWS CLI](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 - [jq](https://stedolan.github.io/jq/download/)
 - [peco](https://github.com/peco/peco#installation)
+- perl (preinstalled on macOS and most Linux distributions; used to relay the remote exit code)
 
 ## Install
 ```bash
@@ -44,7 +45,7 @@ cd sssh
 ```
 **Note**: Before running the script, ensure that the AWS CLI profile you use is configured to output in JSON format. Otherwise, the script will crash. Running `aws configure` only sets the `default` profile, so configure the profile you pass to `--profile` explicitly: `aws configure set output json --profile foo-profile`.
 
-**Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
+**Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. The output passes through byte-for-byte (NUL-safe), so binary output such as tar streams also survives. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
 
 **Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ cd sssh
 
 **Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
 
+**Note**: ECS Exec runs the remote command on a PTY (pseudo-terminal) inside the SSM agent, so stdout is text-oriented (e.g. `\n` may be translated to `\r\n`). Binary output such as tar/gzip streams is NOT preserved — this is an ECS Exec limitation, not an sssh one. Transfer files via S3 or similar instead.
+
 **Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 
 **Note**: Do not embed passwords or tokens in `--command`. The command line is shown on screen, kept in your local shell history, and recorded in CloudTrail; with ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - [Session Manager plugin for the AWS CLI](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
 - [jq](https://stedolan.github.io/jq/download/)
 - [peco](https://github.com/peco/peco#installation)
-- perl (preinstalled on macOS and most Linux distributions; used to relay the remote exit code)
 
 ## Install
 ```bash
@@ -45,7 +44,7 @@ cd sssh
 ```
 **Note**: Before running the script, ensure that the AWS CLI profile you use is configured to output in JSON format. Otherwise, the script will crash. Running `aws configure` only sets the `default` profile, so configure the profile you pass to `--profile` explicitly: `aws configure set output json --profile foo-profile`.
 
-**Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. The output passes through byte-for-byte (NUL-safe), so binary output such as tar streams also survives. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
+**Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
 
 **Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,17 @@ cd sssh
 
 ## Usage
 ```bash
-# Select profile, cluster, service, container, and task, and run sh
+# Select profile, cluster, service, container, and task, and run an interactive sh
 ./sssh
 
 # Run a one-off command on the container ("--opt value" and "--opt=value" both work)
 ./sssh --command "php -v"
 ./sssh --command="php -v"
 
-# Pipes, redirects, and variable expansion require an explicit shell
-./sssh --command 'sh -c "php -v | head -n 1"'
-
-# Get the remote command's exit code (opt-in)
-./sssh --command 'exit 7' --exit-code ; echo $?  # => 7
+# The command is wrapped in "/bin/sh -c ...", so pipes work directly,
+# and the remote command's exit code becomes the exit code of sssh
+./sssh --command "php -v | head -n 1"
+./sssh --command 'exit 7' ; echo $?  # => 7
 
 # Run port forwarding
 ./sssh --remote-host rds.example.com --remote-port 3306 --local-port 13306
@@ -45,7 +44,7 @@ cd sssh
 ```
 **Note**: Before running the script, ensure that the AWS CLI profile you use is configured to output in JSON format. Otherwise, the script will crash. Running `aws configure` only sets the `default` profile, so configure the profile you pass to `--profile` explicitly: `aws configure set output json --profile foo-profile`.
 
-**Note**: By default, the exit code of the remote command is NOT reflected in the exit code of this script (an ECS Exec limitation). Use `--exit-code` to opt in; the command is then wrapped in `/bin/sh -c` and the exit code is relayed, which makes it usable from CI pipelines and AI agents.
+**Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
 
 **Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ cd sssh
 # Pipes, redirects, and variable expansion require an explicit shell
 ./sssh --command 'sh -c "php -v | head -n 1"'
 
+# Get the remote command's exit code (opt-in)
+./sssh --command 'exit 7' --exit-code ; echo $?  # => 7
+
 # Run port forwarding
 ./sssh --remote-host rds.example.com --remote-port 3306 --local-port 13306
 
@@ -42,7 +45,9 @@ cd sssh
 ```
 **Note**: Before running the script, ensure that the AWS CLI profile you use is configured to output in JSON format. Otherwise, the script will crash. Running `aws configure` only sets the `default` profile, so configure the profile you pass to `--profile` explicitly: `aws configure set output json --profile foo-profile`.
 
-**Note**: The exit code of the remote command is NOT reflected in the exit code of this script (an ECS Exec limitation), so it is not suitable for CI pipelines.
+**Note**: By default, the exit code of the remote command is NOT reflected in the exit code of this script (an ECS Exec limitation). Use `--exit-code` to opt in; the command is then wrapped in `/bin/sh -c` and the exit code is relayed, which makes it usable from CI pipelines and AI agents.
+
+**Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 
 **Note**: Do not embed passwords or tokens in `--command`. The command line is shown on screen, kept in your local shell history, and recorded in CloudTrail; with ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd sssh
 
 **Note**: Since v5.0.0, when `--command` is given, it is wrapped in `/bin/sh -c ...` and the exit code of the remote command becomes the exit code of this script, which makes it usable from CI pipelines and AI agents. For an interactive shell, run without `--command` (the exit code capture would garble interactive prompts, so it is disabled in that case; the exit code is then not reflected, an ECS Exec limitation).
 
-**Note**: ECS Exec runs the remote command on a PTY (pseudo-terminal) inside the SSM agent, so stdout is text-oriented (e.g. `\n` may be translated to `\r\n`). Binary output such as tar/gzip streams is NOT preserved — this is an ECS Exec limitation, not an sssh one. Transfer files via S3 or similar instead.
+**Note**: ECS Exec runs the remote command on a PTY (pseudo-terminal) inside the SSM agent, so stdout is text-oriented (e.g. `\n` may be translated to `\r\n`). Binary output such as tar/gzip streams is NOT preserved — this is an ECS Exec limitation, not a limitation of `sssh`. Transfer files via S3 or similar instead.
 
 **Note**: Since v5.0.0, all informational messages (date, Profile/Cluster/Service/Task/Container, the executed command line) go to stderr. stdout carries only the output of the remote command, so `./sssh --command 'php -v' | grep PHP` works as expected.
 

--- a/sssh
+++ b/sssh
@@ -86,6 +86,10 @@ END
 
 main(){
   command='/bin/sh'
+  # Initialize explicitly so exported environment variables with the same
+  # names cannot enable these modes.
+  commandSpecified=
+  exitCodeMode=
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       -h|--help)
@@ -175,7 +179,7 @@ main(){
 
   if [[ -n "${exitCodeMode:-}" ]]; then
     [[ -n "${commandSpecified:-}" ]] || die "--exit-code requires --command"
-    if [ ! -z ${remotePort+x} ] || [ ! -z ${localPort+x} ] || [ ! -z ${remoteHost+x} ]; then
+    if [ -n "${remotePort+x}" ] || [ -n "${localPort+x}" ] || [ -n "${remoteHost+x}" ]; then
       die "--exit-code cannot be used with port forwarding"
     fi
     # Make the remote shell print its exit code on a marker line. The ( )

--- a/sssh
+++ b/sssh
@@ -255,54 +255,26 @@ main(){
   colorEcho "${cmd[@]}"
   if [[ -n "$captureExit" ]]; then
     markerFile=$(mktemp)
-    # Stream the output through byte-for-byte (NUL-safe, so binary output
-    # like tar streams survives), while scanning for the marker, which may
-    # appear mid-stream (the Session Manager "Exiting session" banner follows
-    # it). On a match, the exit code (1-3 digits) and one trailing newline
-    # are removed from the stream and the code is stored in markerFile;
-    # everything else, before and after, is passed through verbatim. The
-    # marker contains a per-run random id, so regular output cannot fake it.
-    "${cmd[@]}" | perl -e '
-      binmode STDIN; binmode STDOUT;
-      my ($m, $f) = @ARGV;
-      my $keep = length($m) + 8;
-      my ($buf, $found) = ("", 0);
-      my $scan = sub {
-        my ($eof) = @_;
-        while (1) {
-          my $p = index($buf, $m);
-          if ($p < 0) {
-            if ($eof) { print $buf; $buf = ""; }
-            elsif (length($buf) > $keep) { print substr($buf, 0, length($buf) - $keep, ""); }
-            return;
-          }
-          my $rest = substr($buf, $p + length($m));
-          # Digits (or their terminating newline) may still be in flight.
-          return if !$eof && $rest =~ /^\d{0,3}\r?\z/;
-          if ($rest =~ /^(\d{1,3})(?!\d)/) {
-            print substr($buf, 0, $p);
-            open(my $fh, ">", $f) or die "sssh: cannot write $f: $!\n";
-            print $fh $1;
-            close $fh;
-            $buf = substr($rest, length($1));
-            $buf =~ s/^\r?\n//;
-            $found = 1;
-            print $buf;
-            $buf = "";
-            return;
-          }
-          # Marker-lookalike without a valid code: emit it and keep scanning.
-          print substr($buf, 0, $p + length($m), "");
+    # The marker+digits at the end of a record is the exit code; anything
+    # before it on the same record is command output that did not end with a
+    # newline (e.g. printf without \n), so emit it verbatim without adding
+    # one. Only the trailing \r that Session Manager may append after the
+    # code is stripped before matching. The marker contains a per-run random
+    # id, so regular output cannot fake it.
+    "${cmd[@]}" | awk -v m="$exitMarker" -v f="$markerFile" '{
+      i = index($0, m)
+      if (i > 0) {
+        c = substr($0, i + length(m))
+        sub(/\r+$/, "", c)
+        if (c ~ /^[0-9]+$/) {
+          print c > f
+          if (i > 1) printf "%s", substr($0, 1, i - 1)
+          next
         }
-      };
-      while (read(STDIN, my $chunk, 65536)) {
-        if ($found) { print $chunk; next; }
-        $buf .= $chunk;
-        $scan->(0);
       }
-      $scan->(1) unless $found;
-    ' "$exitMarker" "$markerFile"
-    # The pipeline status above is perl's, so grab aws's separately.
+      print
+    }'
+    # The pipeline status above is awk's, so grab aws's separately.
     awsExit=${PIPESTATUS[0]}
     remoteExit=$(cat "$markerFile")
     rm -f "$markerFile"

--- a/sssh
+++ b/sssh
@@ -274,10 +274,19 @@ main(){
       }
       print
     }'
+    # The pipeline status above is awk's, so grab aws's separately.
+    awsExit=${PIPESTATUS[0]}
     remoteExit=$(cat "$markerFile")
     rm -f "$markerFile"
-    [[ -n "$remoteExit" ]] || die "Could not detect the remote exit code (the remote command may not have started)."
-    exit "$remoteExit"
+    # The marker means the remote command ran to completion; its code wins.
+    if [[ -n "$remoteExit" ]]; then
+      exit "$remoteExit"
+    fi
+    if [[ "$awsExit" -ne 0 ]]; then
+      echo_stderr "aws ecs execute-command failed with exit code ${awsExit}."
+      exit "$awsExit"
+    fi
+    die "Could not detect the remote exit code (the remote command may not have started)."
   fi
   "${cmd[@]}"
 }

--- a/sssh
+++ b/sssh
@@ -175,13 +175,16 @@ main(){
   # is collected locally. The ( ) subshell keeps a plain "exit N" from
   # skipping the echo. The command is single-quoted (embedded ' escaped as
   # '\'') so that nothing in it is interpreted before the inner /bin/sh runs
-  # it, and $? is expanded only by that inner shell.
+  # it, and $? is expanded only by that inner shell. A real newline before
+  # the closing paren keeps a trailing "# comment" in the command from
+  # commenting out the marker echo.
   captureExit=
   if [[ -n "${commandSpecified:-}" ]] && [ -z "${remotePort+x}" ] && [ -z "${localPort+x}" ] && [ -z "${remoteHost+x}" ]; then
     captureExit=1
     exitMarker="__SSSH_EXIT_${RANDOM}${RANDOM}__:"
     escapedCommand=${command//\'/\'\\\'\'}
-    command="/bin/sh -c '(${escapedCommand}); echo ${exitMarker}\$?'"
+    command="/bin/sh -c '(${escapedCommand}
+); echo ${exitMarker}\$?'"
   fi
 
   date >&2

--- a/sssh
+++ b/sssh
@@ -255,26 +255,54 @@ main(){
   colorEcho "${cmd[@]}"
   if [[ -n "$captureExit" ]]; then
     markerFile=$(mktemp)
-    # The marker+digits at the end of a record is the exit code; anything
-    # before it on the same record is command output that did not end with a
-    # newline (e.g. printf without \n), so emit it verbatim without adding
-    # one. Only the trailing \r that Session Manager may append after the
-    # code is stripped before matching. The marker contains a per-run random
-    # id, so regular output cannot fake it.
-    "${cmd[@]}" | awk -v m="$exitMarker" -v f="$markerFile" '{
-      i = index($0, m)
-      if (i > 0) {
-        c = substr($0, i + length(m))
-        sub(/\r+$/, "", c)
-        if (c ~ /^[0-9]+$/) {
-          print c > f
-          if (i > 1) printf "%s", substr($0, 1, i - 1)
-          next
+    # Stream the output through byte-for-byte (NUL-safe, so binary output
+    # like tar streams survives), while scanning for the marker, which may
+    # appear mid-stream (the Session Manager "Exiting session" banner follows
+    # it). On a match, the exit code (1-3 digits) and one trailing newline
+    # are removed from the stream and the code is stored in markerFile;
+    # everything else, before and after, is passed through verbatim. The
+    # marker contains a per-run random id, so regular output cannot fake it.
+    "${cmd[@]}" | perl -e '
+      binmode STDIN; binmode STDOUT;
+      my ($m, $f) = @ARGV;
+      my $keep = length($m) + 8;
+      my ($buf, $found) = ("", 0);
+      my $scan = sub {
+        my ($eof) = @_;
+        while (1) {
+          my $p = index($buf, $m);
+          if ($p < 0) {
+            if ($eof) { print $buf; $buf = ""; }
+            elsif (length($buf) > $keep) { print substr($buf, 0, length($buf) - $keep, ""); }
+            return;
+          }
+          my $rest = substr($buf, $p + length($m));
+          # Digits (or their terminating newline) may still be in flight.
+          return if !$eof && $rest =~ /^\d{0,3}\r?\z/;
+          if ($rest =~ /^(\d{1,3})(?!\d)/) {
+            print substr($buf, 0, $p);
+            open(my $fh, ">", $f) or die "sssh: cannot write $f: $!\n";
+            print $fh $1;
+            close $fh;
+            $buf = substr($rest, length($1));
+            $buf =~ s/^\r?\n//;
+            $found = 1;
+            print $buf;
+            $buf = "";
+            return;
+          }
+          # Marker-lookalike without a valid code: emit it and keep scanning.
+          print substr($buf, 0, $p + length($m), "");
         }
+      };
+      while (read(STDIN, my $chunk, 65536)) {
+        if ($found) { print $chunk; next; }
+        $buf .= $chunk;
+        $scan->(0);
       }
-      print
-    }'
-    # The pipeline status above is awk's, so grab aws's separately.
+      $scan->(1) unless $found;
+    ' "$exitMarker" "$markerFile"
+    # The pipeline status above is perl's, so grab aws's separately.
     awsExit=${PIPESTATUS[0]}
     remoteExit=$(cat "$markerFile")
     rm -f "$markerFile"

--- a/sssh
+++ b/sssh
@@ -28,7 +28,7 @@ colorEcho(){
     color=$green
   fi
 
-  echo -e "${color}$@${reset}"
+  echo -e "${color}$@${reset}" >&2
 }
 
 echo_stderr() {
@@ -58,6 +58,8 @@ Supported input parameters (both "--opt value" and "--opt=value" forms work):
  -r | --region      : AWS Region to fetch the cluster, service, task
  -p | --profile     : AWS Profile for credentials and region.
  -c | --command     : Command to execute, defaults to '/bin/sh'.
+      --exit-code   : Exit with the remote command's exit code. Requires --command.
+                      The command is wrapped in "/bin/sh -c ...", so pipes work directly.
       --cluster     : Cluster name.
       --service     : Service name.
       --task        : Task name.
@@ -72,8 +74,9 @@ If you want to execute a different command or shell, you can pass it in like so:
 ./sssh --command 'php -v'
 Pipes, redirects, and variable expansion require an explicit shell:
 ./sssh --command 'sh -c "php -v | head -n 1"'
-Note: the exit code of the remote command is NOT reflected in the exit code of
-this script (an ECS Exec limitation).
+By default, the exit code of the remote command is NOT reflected in the exit
+code of this script (an ECS Exec limitation). Use --exit-code to opt in:
+./sssh --command 'exit 7' --exit-code ; echo $?  # => 7
 Note: do not embed passwords or tokens in --command. The command line is shown
 on screen, kept in your local shell history, and recorded in CloudTrail; with
 ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.
@@ -90,7 +93,7 @@ main(){
         exit
         ;;
       -v|--version)
-        echo "sssh version v4.2.0"
+        echo "sssh version v5.0.0"
         exit
         ;;
       -r|--region)
@@ -114,9 +117,14 @@ main(){
       -c|--command)
         shift
         command="${1:?Command must be specified in --command}"
+        commandSpecified=1
         shift
         ;;
-      --command=*) command=$(optValue "$1"); shift ;;
+      --command=*) command=$(optValue "$1"); commandSpecified=1; shift ;;
+      --exit-code)
+        exitCodeMode=1
+        shift
+        ;;
       --cluster)
         shift
         cluster="${1:?Cluster must be specified in --cluster}"
@@ -165,7 +173,22 @@ main(){
     esac
   done
 
-  date
+  if [[ -n "${exitCodeMode:-}" ]]; then
+    [[ -n "${commandSpecified:-}" ]] || die "--exit-code requires --command"
+    if [ ! -z ${remotePort+x} ] || [ ! -z ${localPort+x} ] || [ ! -z ${remoteHost+x} ]; then
+      die "--exit-code cannot be used with port forwarding"
+    fi
+    # Make the remote shell print its exit code on a marker line. The ( )
+    # subshell keeps a plain "exit N" from skipping the echo. The command is
+    # single-quoted (embedded ' escaped as '\'') so that nothing in it is
+    # interpreted before the inner /bin/sh runs it, and $? is expanded only
+    # by that inner shell.
+    exitMarker="__SSSH_EXIT_${RANDOM}${RANDOM}__:"
+    escapedCommand=${command//\'/\'\\\'\'}
+    command="/bin/sh -c '(${escapedCommand}); echo ${exitMarker}\$?'"
+  fi
+
+  date >&2
 
   echo_stderr "Select AWS Profile"
   if [ -z ${profile+x} ]; then
@@ -231,6 +254,32 @@ main(){
   fi
 
   colorEcho "${cmd[@]}"
+  if [[ -n "${exitCodeMode:-}" ]]; then
+    markerFile=$(mktemp)
+    # The marker+digits at the end of a record is the exit code; anything
+    # before it on the same record is command output that did not end with a
+    # newline (e.g. printf without \n), so emit it verbatim without adding
+    # one. Only the trailing \r that Session Manager may append after the
+    # code is stripped before matching. The marker contains a per-run random
+    # id, so regular output cannot fake it.
+    "${cmd[@]}" | awk -v m="$exitMarker" -v f="$markerFile" '{
+      i = index($0, m)
+      if (i > 0) {
+        c = substr($0, i + length(m))
+        sub(/\r+$/, "", c)
+        if (c ~ /^[0-9]+$/) {
+          print c > f
+          if (i > 1) printf "%s", substr($0, 1, i - 1)
+          next
+        }
+      }
+      print
+    }'
+    remoteExit=$(cat "$markerFile")
+    rm -f "$markerFile"
+    [[ -n "$remoteExit" ]] || die "Could not detect the remote exit code (the remote command may not have started)."
+    exit "$remoteExit"
+  fi
   "${cmd[@]}"
 }
 

--- a/sssh
+++ b/sssh
@@ -58,8 +58,6 @@ Supported input parameters (both "--opt value" and "--opt=value" forms work):
  -r | --region      : AWS Region to fetch the cluster, service, task
  -p | --profile     : AWS Profile for credentials and region.
  -c | --command     : Command to execute, defaults to '/bin/sh'.
-      --exit-code   : Exit with the remote command's exit code. Requires --command.
-                      The command is wrapped in "/bin/sh -c ...", so pipes work directly.
       --cluster     : Cluster name.
       --service     : Service name.
       --task        : Task name.
@@ -69,14 +67,14 @@ Supported input parameters (both "--opt value" and "--opt=value" forms work):
       --local-port  : Local port number for port forward.
 The default command executed on the selected container is '/bin/sh'.
 If a region is not provided, the script will attempt to use your region set in the profile.
-If you want to execute a different command or shell, you can pass it in like so:
-./sssh --command '/bin/bash'
+If you want to execute a different command, you can pass it in like so:
 ./sssh --command 'php -v'
-Pipes, redirects, and variable expansion require an explicit shell:
-./sssh --command 'sh -c "php -v | head -n 1"'
-By default, the exit code of the remote command is NOT reflected in the exit
-code of this script (an ECS Exec limitation). Use --exit-code to opt in:
-./sssh --command 'exit 7' --exit-code ; echo $?  # => 7
+When --command is given, it is wrapped in "/bin/sh -c ...", so pipes work
+directly, and the exit code of the remote command becomes the exit code of
+this script:
+./sssh --command 'exit 7' ; echo $?  # => 7
+For an interactive shell, run without --command (the exit code capture would
+garble interactive prompts, so it is disabled in that case).
 Note: do not embed passwords or tokens in --command. The command line is shown
 on screen, kept in your local shell history, and recorded in CloudTrail; with
 ECS Exec logging enabled it may also be stored in CloudWatch Logs / S3.
@@ -86,10 +84,9 @@ END
 
 main(){
   command='/bin/sh'
-  # Initialize explicitly so exported environment variables with the same
-  # names cannot enable these modes.
+  # Initialize explicitly so an exported environment variable with the same
+  # name cannot affect the behavior.
   commandSpecified=
-  exitCodeMode=
   while [[ "$#" -gt 0 ]]; do
     case $1 in
       -h|--help)
@@ -125,10 +122,6 @@ main(){
         shift
         ;;
       --command=*) command=$(optValue "$1"); commandSpecified=1; shift ;;
-      --exit-code)
-        exitCodeMode=1
-        shift
-        ;;
       --cluster)
         shift
         cluster="${1:?Cluster must be specified in --cluster}"
@@ -177,16 +170,15 @@ main(){
     esac
   done
 
-  if [[ -n "${exitCodeMode:-}" ]]; then
-    [[ -n "${commandSpecified:-}" ]] || die "--exit-code requires --command"
-    if [ -n "${remotePort+x}" ] || [ -n "${localPort+x}" ] || [ -n "${remoteHost+x}" ]; then
-      die "--exit-code cannot be used with port forwarding"
-    fi
-    # Make the remote shell print its exit code on a marker line. The ( )
-    # subshell keeps a plain "exit N" from skipping the echo. The command is
-    # single-quoted (embedded ' escaped as '\'') so that nothing in it is
-    # interpreted before the inner /bin/sh runs it, and $? is expanded only
-    # by that inner shell.
+  # When a command is given (and this is not a port forward), propagate the
+  # remote exit code: make the remote shell print it on a marker line that
+  # is collected locally. The ( ) subshell keeps a plain "exit N" from
+  # skipping the echo. The command is single-quoted (embedded ' escaped as
+  # '\'') so that nothing in it is interpreted before the inner /bin/sh runs
+  # it, and $? is expanded only by that inner shell.
+  captureExit=
+  if [[ -n "${commandSpecified:-}" ]] && [ -z "${remotePort+x}" ] && [ -z "${localPort+x}" ] && [ -z "${remoteHost+x}" ]; then
+    captureExit=1
     exitMarker="__SSSH_EXIT_${RANDOM}${RANDOM}__:"
     escapedCommand=${command//\'/\'\\\'\'}
     command="/bin/sh -c '(${escapedCommand}); echo ${exitMarker}\$?'"
@@ -258,7 +250,7 @@ main(){
   fi
 
   colorEcho "${cmd[@]}"
-  if [[ -n "${exitCodeMode:-}" ]]; then
+  if [[ -n "$captureExit" ]]; then
     markerFile=$(mktemp)
     # The marker+digits at the end of a record is the exit code; anything
     # before it on the same record is command output that did not end with a


### PR DESCRIPTION
Closes #15
Closes #16

## 何が課題なのか

1. **リモートコマンドの終了コードが常に 0 になる**（#15）。ECS Exec の制限により、`sssh --command 'exit 7'` でもローカルの終了コードは 0。AIエージェントやスクリプトから使うと失敗を握りつぶして先に進んでしまう実害が報告されています。
2. **情報メッセージが stdout に混ざる**（#16）。`date` と colorEcho（Profile / Cluster / Service / Task / Container / 実行コマンド行）が stdout に出るため、`--command 'echo HELLO'` の stdout 16行のうち必要なのは1行だけ、という状態でした。

## なぜこの実装方針を選んだのか

### #16: 情報メッセージを stderr へ

- `colorEcho` の出力と `date` を stderr に変更。案内メッセージ（`echo_stderr`）は元々 stderr なので、これで情報メッセージの行き先が stderr に統一されます
- 人間の見た目は従来どおり（本番環境を赤く表示する安全装置もそのまま）。stdout にはリモートコマンドの出力（と AWS CLI 由来の Session Manager メッセージ）だけが流れ、`./sssh --command 'php -v' | grep PHP` が期待どおり動きます

### #15: `--command` 指定時は終了コードを伝搬（デフォルト挙動）

- v5.0.0 は breaking change として出すため、オプトインではなく **`--command` 指定時のデフォルト挙動**にしました（オーナー判断）
- 仕組み: コマンドを `/bin/sh -c '(元コマンド); echo <マーカー>$?'` にラップし、ローカル側の awk がマーカー行を回収・除去して終了コードとして exit します
  - **単一引用符でラップ**し、元コマンド内の `'` は `'\''` にエスケープ。`$?` や引用符・変数がリモートの内側シェル実行前に解釈されることを防ぎます（Issue #15 で実測済みの形式と同じ）
  - **マーカーは実行ごとのランダムID付き**（`__SSSH_EXIT_<乱数>__:`）で、レコード末尾の「マーカー+数字」のみ照合。通常出力がマーカーに偽装される事故を防ぎます
  - コマンド出力が改行なしで終わる場合（`printf HELLO` 等）はマーカーと同一レコードになりますが、マーカー前の部分を改行を足さずにそのまま通過させます
  - Session Manager が付ける行末 `\r` は照合時のみ除去し、通常出力は無加工で通過させます
  - **テキスト前提です**: ECS Exec は SSM Agent 内の PTY（疑似端末）経由でコマンドを実行するため、`\n`→`\r\n` 変換などが起こり、stdout はそもそもバイナリ非透過です（sssh ではなく ECS Exec の制約）。tar 等のバイナリ転送は S3 などを使う前提とし、README に明記しました。一時的に perl 製バイト透過パーサへの置換も試みましたが、トランスポート自体が非透過なためローカルだけ透過にしても保証にならず、awk 版に戻しています（依存追加も撤回）
- **対話モード（`--command` なし、既定 `/bin/sh`）は従来どおり**。終了コード回収は stdout を awk に通すため、対話シェルではプロンプト表示（改行なしの行）が崩れます。そのため対話シェルは素の `./sssh` を使う前提とし、README / help に明記しました
- ポートフォワードモードでは `--command` は元々使われないため、伝搬は行いません
- **`aws` コマンド自体が失敗した場合の挙動**:
  - 選択フェーズ（list-clusters 等）: `set -eu` に `pipefail` がないため、`aws | jq | sort | peco` の途中の aws 失敗は握りつぶされ、候補ゼロの peco が起動します（#17 の「真っ白な画面」。fake aws で再現確認済み）。この修正は #17 の対応範囲とし、本PRでは変更しません
  - ポートフォワード用の `describe-tasks | jq` も同様に握りつぶされ、`containerId` が空のまま進み、最後の `ssm start-session` が失敗して非0で停止します（fake aws で確認済み）。これも #17 と同根（pipefail 不在）のため本PRでは変更しません
  - `--command` なしの execute-command: `set -e` により aws の終了コードがそのまま sssh の終了コードになります（従来どおり）
  - `--command` ありの execute-command: マーカーがあればリモートの終了コードを優先（コマンドは完走しているため）。マーカーがなく aws が非0で終了した場合は「aws ecs execute-command failed with exit code N.」を stderr に出して **aws の終了コードをそのまま伝搬**します（例: 認証切れの 253）。aws が 0 なのにマーカーがない異常時は exit 1 です

## 他の選択肢と、採用しなかった理由

- **`--exit-code` オプトイン**: 当初この形で実装しましたが、v5.0.0 として互換性を割り切れるため、エージェント利用の主目的に合わせてデフォルト化しました。オプションが1つ減り、使う側が「付け忘れて失敗を握りつぶす」事故もなくなります
- **二重引用符でのラップ**: コマンド内の `"` や `$` がリモートの外側で先に解釈され、`exit 7` が 0 になるケースがあるため不採用
- **固定マーカー**: 通常出力にマーカーと同じ文字列が含まれると出力が消える・終了コードを誤認するため、ランダムID付き+行末厳密照合にしました
- **対話モードにも伝搬を適用**: awk の行バッファリングで改行なしのプロンプトが表示されなくなるため不採用

## 利用者や既存機能への影響

- **stdout → stderr（#16）**: sssh の stdout をパースしていた呼び出し側は、情報メッセージが stderr に移ることで見え方が変わります。人間の対話利用では画面表示は変わりません
- **終了コード伝搬（#15）**: `--command` 指定時、これまで常に 0 だった終了コードがリモートの結果を反映するようになります。`sssh --command ...` の失敗を無視していた既存スクリプトは、`set -e` 環境下で止まるようになります（これが本来の意図です）
- `--command` が `/bin/sh -c` でラップされるため、パイプ・リダイレクトが明示シェルなしで使えるようになります
- `--command '/bin/bash'` のような対話シェル用途は非推奨になります（プロンプト表示が崩れるため、素の `./sssh` を使用）

## リスク、制約、未解決事項

- `--command` 指定時はリモートコンテナに `/bin/sh` があることが前提です（ECS Exec 自体もシェルを要求するため、実質的な追加制約はほぼありません）
- 実際の ECS 環境での動作確認は fake aws によるシミュレーションであり、実環境での確認は下記「動作確認方法」の手順でお願いします
- 選択フェーズおよびポートフォワード用 `describe-tasks` の aws 失敗は、`pipefail` 不在により後段コマンドに握りつぶされます（従来からの挙動）。認証切れ時の「真っ白な peco」を含め、#17 で対応予定のため本PRの対象外です

## 人間に確認・判断してほしい点

- `--command` での対話シェル利用（例: `--command '/bin/bash'`）を非推奨とする整理でよいか
- v5.0.0（メジャーバージョンアップ）として出すことの妥当性

## 動作確認方法と確認結果

実際の `aws` の代わりに、受け取った `--command` 文字列を shell-words 分割（Python `shlex`）して実行する fake `aws` を PATH に置き、ECS エージェントでの再解釈境界を再現して確認しました。

| ケース | 結果 |
|---|---|
| `exit 7` | rc=7 |
| `printf 'a\nb\n' \| wc -l`（明示シェルなしのパイプ） | 出力 `2`, rc=0 |
| `printf HELLO; exit 7`（無改行出力） | 出力 `HELLO`（改行追加なし）, rc=7 |
| `printf 'A\rB'; exit 4`（埋め込みCR・無改行） | バイト列 `A \r B` 無加工, rc=4 |
| Session Manager バナー（前後）付き出力 | バナー・出力とも従来どおり表示、rc は正しく伝搬 |
| `echo 'hello world'; false`（単一引用符） | 出力 `hello world`, rc=1 |
| `echo "a b"`（二重引用符） | 出力 `a b`, rc=0 |
| `echo __SSSH_EXIT_123__:9; exit 5`（マーカー風の通常出力） | 出力そのまま通過, rc=5 |
| `--command` なし（対話モード） | ラップされず従来どおり（fake aws が受信した文字列は `/bin/sh` のまま） |
| 環境変数 `commandSpecified=1` 等の注入 | 影響なし（main 冒頭で初期化済み） |
| `true # comment` / `false # comment` / `exit 7 # done`（末尾コメント） | rc=0 / 1 / 7 |
| aws が 253 で失敗（認証切れ相当、マーカーなし） | エラー表示のうえ rc=253 を伝搬 |
| aws が 0 で終了したがマーカーなし（異常系） | エラー表示のうえ rc=1 |

そのほか `bash -n` による構文チェック、`--help` / `--version` の表示確認済みです。

実環境での確認手順（レビュー時にお願いしたい確認）:

```bash
./sssh --profile <profile> ... --command 'exit 7' ; echo $?   # => 7
./sssh ... --command 'php -v' | grep PHP   # 情報メッセージが混ざらないこと
./sssh                                     # 対話シェルが従来どおり使えること
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **変更**
  - `--command` 実行時は常にシェル経由となり、パイプを直接利用できるようになりました。
  - リモートコマンドの終了コードが `sssh` の終了コードとして返されます（ポートフォワーディング使用時を除く）。
  - `--exit-code` オプションを削除しました。
  - 対話シェルでは終了コードを取得しません。ポートフォワーディングの動作は変更ありません。
  - メッセージの出力先を標準エラーに変更しました。

- **ドキュメント**
  - ヘルプとREADMEの使用方法および制約を更新しました。
  - ECS Execではバイナリ出力を保持できないため、ファイル転送にはS3などを利用してください。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



